### PR TITLE
Adressing #143 and #156: Add vscode files to .gitignore and user info on GitHUb repo creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ This project adheres to `Semantic Versioning <https://semver.org/>`_.
 * added a output-directory parameter option to create command, allowing users to specifify the
   directory, where the project should be created
 
+* added a user information before the user is prompted to create a GitHub repo with mlf-core
+
+* [ALL TEMPLATES] added vscode files to .gitignore for templates
+
 **Fixed**
 
 * fixed a bug causing the check upgrade version function to fail if local version is a SNAPSHOT version

--- a/mlf_core/create/github_support.py
+++ b/mlf_core/create/github_support.py
@@ -181,6 +181,8 @@ def prompt_github_repo(dot_mlf_core: OrderedDict or None) -> (bool, bool, bool, 
 
     # No dot_mlf_core_dict was passed -> prompt whether to create a Github repository and the required settings
     create_git_repo, private, is_github_org, github_org = False, False, False, ''
+    print('[bold blue]Automatically creating a Github repository with mlf-core is strongly recommended. '
+          'Otherwise you will not be able to use all of mlf-core\'s features!\n')
     if mlf_core_questionary_or_dot_mlf_core(function='confirm',
                                             question='Do you want to create a Github repository and push your template to it?',
                                             default='Yes'):

--- a/mlf_core/create/templates/common_files/{{cookiecutter.commonName}}/.gitignore
+++ b/mlf_core/create/templates/common_files/{{cookiecutter.commonName}}/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Jetbrains IDE
 .idea/
+
+# visual studio code
+.vscode


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

 - [x] This comment contains a description of changes (with reason)
 - [x] Referenced issue is linked
 - [x] `CHANGELOG.rst` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

* added user information before GitHub prompts, that encourages users to create a GitHub repo with mlf-core automatically

* added vscode files to all template's .gitignore
