### PR TITLE
add nf-core MIT licenses

### DIFF
--- a/mlf_core/lint/LICENSE
+++ b/mlf_core/lint/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2020-2021 mlf-core
+Copyright (c) 2018 nf-core
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/mlf_core/sync/LICENSE
+++ b/mlf_core/sync/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2020-2021 mlf-core
+Copyright (c) 2018 nf-core
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
We share a little bit of code from nf-core tools and we must add their MIT license.

CC @ggabernet 

Sync diff: https://www.diffchecker.com/SyFCBTU1
Lint diff: https://www.diffchecker.com/9r9onItE

We share less than 5% of the code, but it is still correct and mandatory to add the licenses. I assume that if I had used the dev branch of tools we would be sharing even less.

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

This means that we have no obligation to specify that a program is a derivative work, nor to track the modifications that you made. For merging several MIT licensed software, we just have to copy the various notices (that is copyright statement + text of the license). If the license texts are exactly the same (the authors did not alter the original MIT license), then it is acceptable to just put the text of the license once, after the various copyright statements. 

Signed-off-by: Zethson <lukas.heumos@posteo.net>
