### PR TITLE
Fix data logging

### DIFF
--- a/mlf_core/create/templates/common_mlflow_files/{{ cookiecutter.common_mlflow }}/{{ cookiecutter.project_slug_no_hyphen }}/mlf_core/mlf_core.py
+++ b/mlf_core/create/templates/common_mlflow_files/{{ cookiecutter.common_mlflow }}/{{ cookiecutter.project_slug_no_hyphen }}/mlf_core/mlf_core.py
@@ -134,7 +134,7 @@ class MLFCore:
         try:
             with open(path, 'w') as tmp:
                 tmp.writelines(input_files)
-            dir_hash = md5(path)
+            dir_hash = cls.md5(path)
         finally:
             os.remove(path)
 

--- a/mlf_core/create/templates/common_mlflow_files/{{ cookiecutter.common_mlflow }}/{{ cookiecutter.project_slug_no_hyphen }}/mlf_core/mlf_core.py
+++ b/mlf_core/create/templates/common_mlflow_files/{{ cookiecutter.common_mlflow }}/{{ cookiecutter.project_slug_no_hyphen }}/mlf_core/mlf_core.py
@@ -152,4 +152,4 @@ class MLFCore:
             input_hash = cls.get_md5_sums(input_data, max_files=max_files)
         else:
             input_hash = cls.md5(input_data)
-        mlflow.log_param("input_hash", input_data + "-" + input_hash)
+        mlflow.log_param("training_data_hash", input_data + "-" + input_hash)

--- a/mlf_core/create/templates/common_mlflow_files/{{ cookiecutter.common_mlflow }}/{{ cookiecutter.project_slug_no_hyphen }}/mlf_core/mlf_core.py
+++ b/mlf_core/create/templates/common_mlflow_files/{{ cookiecutter.common_mlflow }}/{{ cookiecutter.project_slug_no_hyphen }}/mlf_core/mlf_core.py
@@ -104,25 +104,18 @@ class MLFCore:
         return md5sum
 
     @classmethod
-    def get_md5_sums(cls, dir, md5_sums=None):
-        """
-        Recursively go through directories and subdirectories
-        and generate tuples of (<file_path>, <md5sum>)
-        returns: list of tuples
-        """
-        if not md5_sums:
-            md5_sums = []
-        elements = glob.glob(dir + "/*")
-        for elem in elements:
-            # if file, get md5 sum
-            if os.path.isfile(elem):
+    def get_md5_sums(cls, dir):
+        """ Walk through directory and collect md5 sums """
+        # TODO: check whether file or directory
+        input_files = []
+        for root, _, file in os.walk(dir):
+            for elem in file:
+                elem = os.path.join(root, elem)
                 elem_md5 = cls.md5(elem)
-                md5_sums.append((elem, elem_md5))
-            # if directory, apply recursion
-            if os.path.isdir(elem):
-                md5_sums = cls.get_md5_sums(elem, md5_sums)
-            else:
-                continue
+                # Switch out the results directory path with the expected 'output' directory
+                input_files.append({"path": elem, "md5sum": elem_md5})
+
+        return input_files
 
     @classmethod
     def log_input_data(cls, input_data: str):

--- a/mlf_core/create/templates/common_mlflow_files/{{ cookiecutter.common_mlflow }}/{{ cookiecutter.project_slug_no_hyphen }}/mlf_core/mlf_core.py
+++ b/mlf_core/create/templates/common_mlflow_files/{{ cookiecutter.common_mlflow }}/{{ cookiecutter.project_slug_no_hyphen }}/mlf_core/mlf_core.py
@@ -1,4 +1,3 @@
-import glob
 import hashlib
 import tempfile
 import os


### PR DESCRIPTION
<!-- Many thanks for contributing to this project! -->

**PR Checklist**

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs). -->

 - [x] This comment contains a description of changes (with reason)
 - [x] Referenced issue is linked
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.rst` is updated

**Description of changes**

Adds flexible input logging to `mlf_core.py`. The `log_input_data()` function can be given a path to a file or a directory. In case of a file, it will calculate the md5 sum of that file. For a directory, it will hash all the files in it (after sorting them), write those md5sums to a file and hash the file again, giving a single md5sum for the directory. Additionally the user can provide a `max_files` parameter to only hash a certain number of files, to allow for very large projects. (Because of sorting, this should still be deterministic).

Closes https://github.com/mlf-core/mlf-core/issues/324


